### PR TITLE
Fixes Issue #1 - Unknown Prop Warning

### DIFF
--- a/index.cjsx
+++ b/index.cjsx
@@ -33,7 +33,7 @@ class MaskedFormControl extends FormControl
     classes = getClassSet(@props) unless type is 'file'
 
     <MaskedInputField
-      {...@props}
+      {...props}
       type={type}
       id={id}
       className={classNames(className, classes)}

--- a/index.cjsx
+++ b/index.cjsx
@@ -28,7 +28,9 @@ class MaskedFormControl extends FormControl
     {type, id, className} = @props
     id ||= controlId
     props = {}
-    props[k] = v for k, v in @props when k not in ['componentClass', 'type', 'id', 'className', 'bsClass']
+    for k, v of @props
+      if k not in ['componentClass', 'type', 'id', 'className', 'bsClass']
+        props[k] = v
 
     classes = getClassSet(@props) unless type is 'file'
 


### PR DESCRIPTION
This addresses Issue #1 (Unknown Prop Warning). It appears that `this.props` is being passed down instead of the intended `props` subset, and the for loop creating that `props` subset needed a little bit of work. Hopefully this passes muster. It's my first OSS contribution.